### PR TITLE
Refactor cover component to update CONFIG_SCHEMA definition for *.*_SCHEMA deprecations

### DIFF
--- a/esphome/components/dc_blue/cover.py
+++ b/esphome/components/dc_blue/cover.py
@@ -1,20 +1,18 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import cover, binary_sensor
-from esphome.components.dc_blue import DcBlueComponent
+from esphome.components import cover
+from esphome.components.dc_blue import dc_blue_component_ns, DcBlueComponent
 from esphome.components.dc_blue.constants import (
     CONF_DC_BLUE_ID,
-)
-from esphome.const import (
-    CONF_ID,
 )
 
 import esphome.config_validation as cv
 
 DEPENDENCIES = ["dc_blue", "cover"]
 
+DcBlueCover = dc_blue_component_ns.class_("DcBlueCover", cover.Cover, cg.Component)
 
-CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
+CONFIG_SCHEMA = cover.cover_schema(DcBlueCover).extend(
     {
         cv.GenerateID(CONF_DC_BLUE_ID): cv.use_id(DcBlueComponent),
     }
@@ -25,6 +23,4 @@ async def to_code(config):
     platform = await cg.get_variable(config[CONF_DC_BLUE_ID])
     
     sens = platform.create_garage_cover_sensor()
-    # sens = cg.new_Pvariable(config[CONF_ID])
     await cover.register_cover(sens, config)
-    # cg.add(platform.set_garage_cover_sensor(sens))


### PR DESCRIPTION
Since ESPHome 2025.6.0, the dc-blue-esphome ESPHome external component has been showing the following warning when building:

`WARNING Using `cover.COVER_SCHEMA` is deprecated and will be removed in ESPHome 2025.11.0. Please use `cover.cover_schema(...)` instead. If you are seeing this, report an issue to the external_component author and ask them to update it. https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/. Component using this schema: cover `

I have refactored the cover component to use "cover.cover_schema(..)" instead as per https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/