### PR TITLE
add esp-idf framework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,36 @@ The component uses the DC Blue's digital interface to read the state of the door
 Control is done via the button trigger input as the digital interface does not support control.
 This component will only work with the DC Blue Advanced range of door motors, not with older models without the digital interface.
 
-> **Note:** This component requires ESPHome 2025.7.0 or newer due to ESP32 Arduino framework changes.
+> **Note:** This component requires ESPHome 2025.7.0 or newer.
+
+## Supported Frameworks
+
+This component supports both ESP32 frameworks:
+
+| Framework | Status | Notes |
+|-----------|--------|-------|
+| **Arduino** | ✅ Supported | Legacy framework |
+| **ESP-IDF** | ✅ Supported | Default framework, smaller binary size |
+
+The component automatically detects which framework is being used and configures the appropriate timer APIs via compile-time directives.
+
+### Framework Selection
+
+To use the Arduino framework (default):
+```yaml
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+```
+
+To use the ESP-IDF framework:
+```yaml
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+```
 
 ## Wiring
 

--- a/dc_blue.yaml
+++ b/dc_blue.yaml
@@ -6,7 +6,7 @@ esphome:
 esp32:
   board: esp32dev
   framework:
-    type: arduino
+    type: esp-idf
 
 # Enable logging
 logger:

--- a/dc_blue_local_arduino.yaml
+++ b/dc_blue_local_arduino.yaml
@@ -1,0 +1,50 @@
+# This config file builds an image using the local component. Usefult for debugging.
+
+external_components:
+  - source:
+      type: local
+      path: esphome/components
+
+logger:
+  level: DEBUG
+
+esphome:
+  name: dc-blue-test
+  build_path: .build/dc_blue_test
+  min_version: 2025.7.0
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+status_led:
+  pin: GPIO2
+
+dc_blue:
+  # Required: Pin where data is received
+  data_pin: GPIO33
+  # Required: Pin which is pulled high to "press button"
+  trigger_pin: GPIO32
+  # Optional: Time per symbol in us
+  symbol_period: 970
+  # Optional: Is the signal from the motor inverted by optocoupler?
+  inverted: True
+  # Optional: Time to press button in ms
+  trigger_period: 1000
+  # Optional: Minimum time between presses in ms
+  clear_period: 1000
+
+binary_sensor:
+  - platform: dc_blue
+    light:
+      name: "Garage Motor Light"
+      
+  - platform: dc_blue
+    ac_power:
+      name: "Garage Motor AC supply"      
+
+cover:
+  - platform: dc_blue
+    name: "Garage Door"
+    device_class: garage

--- a/dc_blue_local_idf.yaml
+++ b/dc_blue_local_idf.yaml
@@ -1,4 +1,4 @@
-# This config file builds an image using the local component. Usefult for debugging.
+# This config file builds using ESP-IDF framework only (no Arduino)
 
 external_components:
   - source:
@@ -9,11 +9,14 @@ logger:
   level: DEBUG
 
 esphome:
-  name: dc-blue-test
-  platform: ESP32
-  board: esp32dev
-  build_path: .build/dc_blue_test
+  name: dc-blue-test-idf
+  build_path: .build/dc_blue_test_idf
   min_version: 2025.7.0
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
 
 status_led:
   pin: GPIO2

--- a/esphome/components/dc_blue/dc_blue.cpp
+++ b/esphome/components/dc_blue/dc_blue.cpp
@@ -1,10 +1,14 @@
 #include "dc_blue.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include <esp32-hal-timer.h>
 
-#define DEBUG_PIN 32
-#define TIMER_PIN 25
+#ifdef USE_ESP32_FRAMEWORK_ARDUINO
+#include <esp32-hal-timer.h>
+#else
+// ESP-IDF native timer API
+#include "driver/gptimer.h"
+#include "esp_attr.h"
+#endif
 
 namespace esphome
 {
@@ -12,28 +16,57 @@ namespace esphome
   {
 
     static const char *const TAG = "dc_blue";
-    DcBlueComponent *instance = NULL;
 
-    hw_timer_t *Timer0_Cfg = NULL;
+    // Instance pointer - volatile since accessed from ISR context
+    static DcBlueComponent *volatile instance = nullptr;
 
-    volatile uint32_t header = 0xFFFFFFFF;
-    volatile uint32_t frame = 0;
-    volatile bool waiting_for_header = true;
-    volatile bool capturing_frame = false;
-    volatile int captured_bytes = 0;
-    volatile int timer_isr_calls = 0;
+#ifdef USE_ESP32_FRAMEWORK_ARDUINO
+    static hw_timer_t *Timer0_Cfg = nullptr;
+#else
+    static gptimer_handle_t gptimer = nullptr;
+#endif
 
-    void IRAM_ATTR Timer0_ISR()
+    // ISR state variables - all volatile for ISR/main thread synchronization
+    static volatile uint32_t header = 0xFFFFFFFF;
+    static volatile uint32_t frame = 0;
+    static volatile bool waiting_for_header = true;
+    static volatile bool capturing_frame = false;
+    static volatile uint8_t captured_bytes = 0; // Only needs 0-24, uint8_t sufficient
+    static volatile uint8_t timer_isr_calls = 0;
+
+    // Queue mask for efficient modulo in ISR - DRAM_ATTR ensures availability when cache disabled
+    static constexpr DRAM_ATTR uint8_t QUEUE_MASK = DcBlueComponent::QUEUE_SIZE - 1;
+    static_assert((DcBlueComponent::QUEUE_SIZE & QUEUE_MASK) == 0, "QUEUE_SIZE must be power of 2");
+
+    // Counter for dropped frames due to queue overflow (set in ISR, read/cleared in loop)
+    static volatile uint8_t frames_dropped = 0;
+
+#ifdef USE_ESP32_FRAMEWORK_ARDUINO
+    static void IRAM_ATTR Timer0_ISR()
+#else
+    static bool IRAM_ATTR Timer0_ISR(gptimer_handle_t timer, const gptimer_alarm_event_data_t *edata, void *user_ctx)
+#endif
     {
-      // digitalWrite(TIMER_PIN, !digitalRead(TIMER_PIN));
-
+      // Sample on odd calls only (half-bit timing)
       timer_isr_calls++;
-      if (timer_isr_calls % 2 != 1)
+      if ((timer_isr_calls & 1) == 0)
       {
+#ifdef USE_ESP32_FRAMEWORK_ARDUINO
         return;
+#else
+        return true;
+#endif
       }
 
-      // digitalWrite(DEBUG_PIN, !digitalRead(DEBUG_PIN));
+      // Safety check - should never happen but prevents null dereference
+      if (instance == nullptr)
+      {
+#ifdef USE_ESP32_FRAMEWORK_ARDUINO
+        return;
+#else
+        return true;
+#endif
+      }
 
       bool value = instance->data_pin_->digital_read();
       if (instance->inverted_)
@@ -43,7 +76,7 @@ namespace esphome
 
       if (waiting_for_header)
       {
-        header = header << 1 | value;
+        header = (header << 1) | value;
         if (header == 0x01)
         {
           header = 0xFFFFFFFF;
@@ -51,30 +84,45 @@ namespace esphome
           capturing_frame = true;
           captured_bytes = 0;
         }
-        return;
       }
-
-      if (capturing_frame)
+      else if (capturing_frame)
       {
-        frame = frame << 1 | value;
+        frame = (frame << 1) | value;
         captured_bytes++;
+
+        if (captured_bytes >= 24)
+        {
+          // Use bitmask for fast modulo (works because QUEUE_SIZE is power of 2)
+          uint8_t write_idx = instance->process_queue_write_;
+          uint8_t next_write_idx = (write_idx + 1) & QUEUE_MASK;
+
+          // Check for queue overflow (would overwrite unread data)
+          if (next_write_idx != instance->process_queue_read_)
+          {
+            instance->process_queue_[write_idx] = frame;
+            instance->process_queue_write_ = next_write_idx;
+          }
+          else
+          {
+            // Queue full - drop frame and increment counter
+            frames_dropped++;
+          }
+
+          // Reset state for next frame
+          waiting_for_header = true;
+          capturing_frame = false;
+          captured_bytes = 0;
+          frame = 0;
+        }
       }
 
-      if (captured_bytes == 24)
-      {
-        waiting_for_header = true;
-        capturing_frame = false;
-        captured_bytes = 0;
-
-        instance->process_queue[instance->process_queue_write] = frame;
-        instance->process_queue_write++;
-        instance->process_queue_write = instance->process_queue_write % (sizeof(instance->process_queue) / sizeof(instance->process_queue[0]));
-
-        frame = 0;
-      }
+#ifndef USE_ESP32_FRAMEWORK_ARDUINO
+      return true;
+#endif
     }
 
-    void IRAM_ATTR pinChangeIrq(hw_timer_t *timer)
+#ifdef USE_ESP32_FRAMEWORK_ARDUINO
+    static void IRAM_ATTR pinChangeIrq(hw_timer_t *timer)
     {
       if (waiting_for_header)
       {
@@ -82,10 +130,31 @@ namespace esphome
         timerRestart(timer);
       }
     }
+#else
+    // Timer handle for ESP-IDF - DRAM_ATTR ensures it's accessible when cache is disabled
+    static DRAM_ATTR gptimer_handle_t idf_gptimer_handle;
+
+    static void IRAM_ATTR pinChangeIrq(gptimer_handle_t *timer_ptr)
+    {
+      if (waiting_for_header && timer_ptr != nullptr)
+      {
+        timer_isr_calls = 0;
+        // Stop timer, reset count, start timer for clean synchronization
+        // This is more reliable than just resetting the count, as it ensures
+        // the alarm state is properly reset. These functions are ISR-safe.
+        gptimer_stop(*timer_ptr);
+        gptimer_set_raw_count(*timer_ptr, 0);
+        gptimer_start(*timer_ptr);
+      }
+    }
+#endif
 
     void DcBlueComponent::setup()
     {
       instance = this;
+
+#ifdef USE_ESP32_FRAMEWORK_ARDUINO
+      // Arduino framework timer initialization
       Timer0_Cfg = timerBegin(1000000);
 
       if (data_pin_ != nullptr)
@@ -104,11 +173,62 @@ namespace esphome
 
       timerAttachInterrupt(Timer0_Cfg, &Timer0_ISR);
       timerAlarm(Timer0_Cfg, this->symbol_period_ / 2, true, 0);
+#else
+      // ESP-IDF native timer initialization
+      gptimer_config_t timer_config = {
+          .clk_src = GPTIMER_CLK_SRC_DEFAULT,
+          .direction = GPTIMER_COUNT_UP,
+          .resolution_hz = 1000000, // 1MHz, 1 tick = 1us
+          .intr_priority = 0,
+          .flags = {
+              .intr_shared = false,
+          },
+      };
+      ESP_ERROR_CHECK(gptimer_new_timer(&timer_config, &gptimer));
 
-      // pinMode(DEBUG_PIN, OUTPUT);
-      // pinMode(TIMER_PIN, OUTPUT);
+      gptimer_alarm_config_t alarm_config = {
+          .alarm_count = static_cast<uint64_t>(this->symbol_period_ / 2),
+          .reload_count = 0,
+          .flags = {
+              .auto_reload_on_alarm = true,
+          },
+      };
+      ESP_ERROR_CHECK(gptimer_set_alarm_action(gptimer, &alarm_config));
 
-      this->garage_cover_sensor_->setup();
+      gptimer_event_callbacks_t cbs = {
+          .on_alarm = Timer0_ISR,
+      };
+      ESP_ERROR_CHECK(gptimer_register_event_callbacks(gptimer, &cbs, NULL));
+
+      // Store timer handle for use in pin change ISR
+      idf_gptimer_handle = gptimer;
+
+      if (data_pin_ != nullptr)
+      {
+        data_pin_->setup();
+        data_pin_->pin_mode(gpio::FLAG_INPUT);
+        data_pin_->attach_interrupt(pinChangeIrq, &idf_gptimer_handle, gpio::INTERRUPT_ANY_EDGE);
+      }
+
+      if (trigger_pin_ != nullptr)
+      {
+        trigger_pin_->setup();
+        trigger_pin_->pin_mode(gpio::FLAG_OUTPUT);
+        trigger_pin_->digital_write(0);
+      }
+
+      ESP_ERROR_CHECK(gptimer_enable(gptimer));
+      ESP_ERROR_CHECK(gptimer_start(gptimer));
+#endif
+
+      if (this->garage_cover_sensor_ != nullptr)
+      {
+        this->garage_cover_sensor_->setup();
+      }
+      else
+      {
+        ESP_LOGE(TAG, "garage_cover_sensor is null - cover will not function");
+      }
 
       ESP_LOGD(TAG, "Assume Light off");
       if (this->light_binary_sensor_ != nullptr)
@@ -125,12 +245,25 @@ namespace esphome
 
     void DcBlueComponent::loop()
     {
-      if (process_queue_read != process_queue_write)
+      // Check for dropped frames (queue overflow) - atomic exchange to avoid missing increments
+      uint8_t dropped = frames_dropped;
+      if (dropped > 0)
       {
-        ESP_LOGD(TAG, "Reading queue location %d", process_queue_read);
-        process_frame(process_queue[process_queue_read]);
-        process_queue_read++;
-        process_queue_read = process_queue_read % (sizeof(instance->process_queue) / sizeof(instance->process_queue[0]));
+        // Note: Small race window here, but worst case we report drops on next iteration
+        frames_dropped -= dropped;
+        ESP_LOGW(TAG, "Queue overflow: %d frame(s) dropped", dropped);
+      }
+
+      // Read volatile write index once to avoid multiple volatile reads
+      uint8_t write_idx = process_queue_write_;
+
+      // Process all pending frames in queue
+      while (process_queue_read_ != write_idx)
+      {
+        ESP_LOGV(TAG, "Reading queue location %d", process_queue_read_);
+        uint32_t frame_to_process = process_queue_[process_queue_read_];
+        process_queue_read_ = (process_queue_read_ + 1) & QUEUE_MASK;
+        process_frame(frame_to_process);
       }
 
       // Check if we need to send a trigger pulse
@@ -139,122 +272,148 @@ namespace esphome
 
     void DcBlueComponent::process_frame(uint32_t frame)
     {
-      switch (frame)
+      uint8_t command = (frame >> 16) & 0xFF;
+      uint8_t state_byte = (frame >> 8) & 0xFF;
+      uint8_t checksum = frame & 0xFF;
+
+      // Expected checksum for known commands: LSB must be set (checksum = state_byte | 0x01)
+      uint8_t expected_checksum = state_byte | 0x01;
+
+      if (command == protocol::CMD_DOOR_STATE)
       {
-      case 0x002C2021: // Door closed on battery
-        ESP_LOGD(TAG, "Door closed - battery");
-        this->process_battery_event(true);
-        this->process_door_closed_event();
-        break;
-      case 0x002C2425:
-        ESP_LOGD(TAG, "Door closed");
-        this->process_battery_event(false);
-        this->process_door_closed_event();
-        break;
-      case 0x002C0809: // Opening/Closing on battery
-        ESP_LOGD(TAG, "Opening/Closing - battery");
-        this->process_battery_event(true);
-        this->process_motor_running_event();
-        break;
-      case 0x002C0C0D:
-        ESP_LOGD(TAG, "Opening/Closing");
-        this->process_battery_event(false);
-        this->process_motor_running_event();
-        break;
-      case 0x002C0203: // Door open on battery
-        ESP_LOGD(TAG, "Door open - battery");
-        this->process_battery_event(true);
-        this->process_door_open_event();
-        break;
-      case 0x002C0607:
-        ESP_LOGD(TAG, "Door open");
-        this->process_battery_event(false);
-        this->process_door_open_event();
-        break;
-      case 0x00551313:
-        ESP_LOGD(TAG, "Light on");
-        this->process_light_event(true);
-        break;
-      case 0x00551515:
-        ESP_LOGD(TAG, "Light off");
-        this->process_light_event(false);
-        break;
-      case 0x00550B0B:
-        ESP_LOGD(TAG, "Strike lock");
-        break;
-      case 0x00550D0D:
-        ESP_LOGD(TAG, "Magnetic lock");
-        break;
-      default:
-        ESP_LOGW(TAG, "Unknown frame received: %08X", frame);
+        if (checksum != expected_checksum)
+        {
+          ESP_LOGW(TAG, "Invalid door frame checksum: %08X (expected %02X)", frame, expected_checksum);
+          return;
+        }
+
+        // Bit 2 indicates AC power (1=AC, 0=battery)
+        bool ac_power = (state_byte & protocol::FLAG_AC_POWER) != 0;
+        uint8_t door_state = state_byte & ~protocol::FLAG_AC_POWER;
+
+        this->process_battery_event(!ac_power);
+
+        switch (door_state)
+        {
+        case protocol::DOOR_CLOSED:
+          ESP_LOGD(TAG, "Door closed%s", ac_power ? "" : " - battery");
+          this->process_door_closed_event();
+          break;
+        case protocol::DOOR_MOVING:
+          ESP_LOGD(TAG, "Opening/Closing%s", ac_power ? "" : " - battery");
+          this->process_motor_running_event();
+          break;
+        case protocol::DOOR_OPEN:
+          ESP_LOGD(TAG, "Door open%s", ac_power ? "" : " - battery");
+          this->process_door_open_event();
+          break;
+        default:
+          ESP_LOGW(TAG, "Unknown door state: %02X (frame: %08X)", door_state, frame);
+        }
+      }
+      else if (command == protocol::CMD_LIGHT_LOCK)
+      {
+        if (checksum != expected_checksum)
+        {
+          ESP_LOGW(TAG, "Invalid light/lock frame checksum: %08X (expected %02X)", frame, expected_checksum);
+          return;
+        }
+
+        switch (state_byte)
+        {
+        case protocol::LIGHT_ON:
+          ESP_LOGD(TAG, "Light on");
+          this->process_light_event(true);
+          break;
+        case protocol::LIGHT_OFF:
+          ESP_LOGD(TAG, "Light off");
+          this->process_light_event(false);
+          break;
+        case protocol::STRIKE_LOCK:
+          ESP_LOGD(TAG, "Strike lock");
+          break;
+        case protocol::MAGNETIC_LOCK:
+          ESP_LOGD(TAG, "Magnetic lock");
+          break;
+        default:
+          ESP_LOGW(TAG, "Unknown light/lock state: %02X (frame: %08X)", state_byte, frame);
+        }
+      }
+      else
+      {
+        // Unknown command - log for analysis (checksum algorithm unknown)
+        ESP_LOGW(TAG, "Unknown command: %02X data: %02X checksum: %02X (frame: %08X)",
+                 command, state_byte, checksum, frame);
       }
     }
 
-    void DcBlueComponent::process_door_open_event() {
+    void DcBlueComponent::process_door_open_event()
+    {
       this->process_door_state_change_event(cover::COVER_OPEN, cover::COVER_OPERATION_CLOSING);
     }
 
-    void DcBlueComponent::process_door_closed_event() {
+    void DcBlueComponent::process_door_closed_event()
+    {
       this->process_door_state_change_event(cover::COVER_CLOSED, cover::COVER_OPERATION_OPENING);
     }
 
-    void DcBlueComponent::process_door_state_change_event(float position, cover::CoverOperation next_direction) {
+    void DcBlueComponent::process_door_state_change_event(float position, cover::CoverOperation next_direction)
+    {
       next_direction_ = next_direction;
 
-      if (this->garage_cover_sensor_ != nullptr)
+      if (this->garage_cover_sensor_ == nullptr)
       {
-        if (garage_cover_sensor_->position != position ||
-            garage_cover_sensor_->current_operation != cover::COVER_OPERATION_IDLE)
-        {
-          garage_cover_sensor_->position = position;
-          garage_cover_sensor_->current_operation = cover::COVER_OPERATION_IDLE;
-          garage_cover_sensor_->publish_state();
-        }
+        return;
       }
-      else
+
+      if (garage_cover_sensor_->position != position ||
+          garage_cover_sensor_->current_operation != cover::COVER_OPERATION_IDLE)
       {
-        ESP_LOGD(TAG, "garage_cover is null");
+        garage_cover_sensor_->position = position;
+        garage_cover_sensor_->current_operation = cover::COVER_OPERATION_IDLE;
+        garage_cover_sensor_->publish_state();
       }
     }
 
-    void DcBlueComponent::process_motor_running_event() {
-      if (this->garage_cover_sensor_ != nullptr)
+    void DcBlueComponent::process_motor_running_event()
+    {
+      if (this->garage_cover_sensor_ == nullptr)
       {
-        if (garage_cover_sensor_->current_operation != next_direction_)
-        {
-          garage_cover_sensor_->current_operation = next_direction_;
-          garage_cover_sensor_->publish_state();
-        }
+        return;
       }
-      else
+
+      if (garage_cover_sensor_->current_operation != next_direction_)
       {
-        ESP_LOGD(TAG, "garage_cover is null");
+        garage_cover_sensor_->current_operation = next_direction_;
+        garage_cover_sensor_->publish_state();
       }
     }
 
-    void DcBlueComponent::process_battery_event(bool battery) {
-      if (this->ac_power_binary_sensor_ != nullptr)
+    void DcBlueComponent::process_battery_event(bool on_battery)
+    {
+      if (this->ac_power_binary_sensor_ == nullptr)
       {
-        if (this->ac_power_binary_sensor_->state == battery) {
-          this->ac_power_binary_sensor_->publish_state(!battery);
-        }
+        return;
       }
-      else
+
+      // ac_power sensor should be true when NOT on battery
+      bool ac_power = !on_battery;
+      if (this->ac_power_binary_sensor_->state != ac_power)
       {
-        ESP_LOGD(TAG, "ac_power_binary_sensor is null");
+        this->ac_power_binary_sensor_->publish_state(ac_power);
       }
     }
 
-    void DcBlueComponent::process_light_event(bool light) {
-      if (this->light_binary_sensor_ != nullptr)
+    void DcBlueComponent::process_light_event(bool light)
+    {
+      if (this->light_binary_sensor_ == nullptr)
       {
-        if (this->light_binary_sensor_->state != light) {
-          this->light_binary_sensor_->publish_state(light);
-        }
+        return;
       }
-      else
+
+      if (this->light_binary_sensor_->state != light)
       {
-        ESP_LOGD(TAG, "light_binary_sensor is null");
+        this->light_binary_sensor_->publish_state(light);
       }
     }
 
@@ -262,33 +421,40 @@ namespace esphome
     {
       if (this->trigger_pin_ == nullptr)
       {
-        ESP_LOGD(TAG, "Trigger pin is null");
-        triggers_needed = 0;
         return;
       }
 
-      if (triggers_needed > 0 && !pin_set && !pin_cleared)
-      {
-        ESP_LOGD(TAG, "Setting pin");
-        triggers_needed--;
-        trigger_pin_->digital_write(1);
-        pin_set = true;
-        pin_set_time = millis();
-      }
+      uint32_t now = millis();
 
-      if (pin_set && (millis() - pin_set_time > this->trigger_period_))
+      switch (trigger_state_)
       {
-        ESP_LOGD(TAG, "Clearing pin");
-        trigger_pin_->digital_write(0);
-        pin_set = false;
-        pin_cleared = true;
-        pin_cleared_time = millis();
-      }
+      case TriggerState::IDLE:
+        if (triggers_needed > 0)
+        {
+          ESP_LOGD(TAG, "Setting trigger pin");
+          triggers_needed--;
+          trigger_pin_->digital_write(1);
+          trigger_state_ = TriggerState::PIN_HIGH;
+          trigger_state_time_ = now;
+        }
+        break;
 
-      if (pin_cleared && (millis() - pin_cleared_time > this->clear_period_))
-      {
-        ESP_LOGD(TAG, "Cleared time passed");
-        pin_cleared = false;
+      case TriggerState::PIN_HIGH:
+        if (now - trigger_state_time_ > this->trigger_period_)
+        {
+          ESP_LOGD(TAG, "Clearing trigger pin");
+          trigger_pin_->digital_write(0);
+          trigger_state_ = TriggerState::PIN_LOW_WAIT;
+          trigger_state_time_ = now;
+        }
+        break;
+
+      case TriggerState::PIN_LOW_WAIT:
+        if (now - trigger_state_time_ > this->clear_period_)
+        {
+          trigger_state_ = TriggerState::IDLE;
+        }
+        break;
       }
     }
 

--- a/esphome/components/dc_blue/dc_blue.h
+++ b/esphome/components/dc_blue/dc_blue.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <vector>
-
+#include <atomic>
 #include "esphome/core/component.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/hal.h"
@@ -13,15 +12,36 @@ namespace esphome
 {
   namespace dc_blue
   {
+    // Protocol constants
+    namespace protocol
+    {
+      // Command bytes (first byte of frame)
+      static constexpr uint8_t CMD_DOOR_STATE = 0x2C;
+      static constexpr uint8_t CMD_LIGHT_LOCK = 0x55;
+
+      // Door state values (after masking out AC bit)
+      static constexpr uint8_t DOOR_CLOSED = 0x20;
+      static constexpr uint8_t DOOR_MOVING = 0x08;
+      static constexpr uint8_t DOOR_OPEN = 0x02;
+
+      // Door state flags
+      static constexpr uint8_t FLAG_AC_POWER = 0x04;
+
+      // Light/lock state values
+      static constexpr uint8_t LIGHT_ON = 0x13;
+      static constexpr uint8_t LIGHT_OFF = 0x15;
+      static constexpr uint8_t STRIKE_LOCK = 0x0B;
+      static constexpr uint8_t MAGNETIC_LOCK = 0x0D;
+    } // namespace protocol
 
     class DcBlueComponent : public Component
     {
 
     public:
-      SUB_BINARY_SENSOR(open)    // CONF_OPEN
-      SUB_BINARY_SENSOR(closed)  // CONF_CLOSED
-      SUB_BINARY_SENSOR(running) // CONF_RUNNING
-      SUB_BINARY_SENSOR(light)   // CONF_LIGHT
+      SUB_BINARY_SENSOR(open)     // CONF_OPEN
+      SUB_BINARY_SENSOR(closed)   // CONF_CLOSED
+      SUB_BINARY_SENSOR(running)  // CONF_RUNNING
+      SUB_BINARY_SENSOR(light)    // CONF_LIGHT
       SUB_BINARY_SENSOR(ac_power) // CONF_AC_POWER
 
       DcBlueCover *create_garage_cover_sensor()
@@ -40,9 +60,8 @@ namespace esphome
       void set_trigger_pin(InternalGPIOPin *trigger_pin) { this->trigger_pin_ = trigger_pin; }
       void set_symbol_period(int symbol_period) { this->symbol_period_ = symbol_period; }
       void set_inverted(bool inverted) { this->inverted_ = inverted; }
-      void set_trigger_period(unsigned long trigger_period) { this->trigger_period_ = trigger_period; }
-      void set_clear_period(unsigned long clear_period) { this->clear_period_ = clear_period; }
-
+      void set_trigger_period(uint32_t trigger_period) { this->trigger_period_ = trigger_period; }
+      void set_clear_period(uint32_t clear_period) { this->clear_period_ = clear_period; }
 
       void process_door_open_event();
       void process_door_closed_event();
@@ -51,14 +70,17 @@ namespace esphome
       void process_battery_event(bool battery);
       void process_light_event(bool light);
 
-      static void interrupt_handler();
       InternalGPIOPin *data_pin_{nullptr};
       InternalGPIOPin *trigger_pin_{nullptr};
       bool inverted_ = false;
 
-      uint32_t process_queue[4];
-      int process_queue_write = 0;
-      int process_queue_read = 0;
+      // Queue for passing frames from ISR to main loop
+      // Size must be power of 2 for efficient masking in ISR
+      static constexpr uint8_t QUEUE_SIZE = 4;
+      static_assert((QUEUE_SIZE & (QUEUE_SIZE - 1)) == 0, "QUEUE_SIZE must be power of 2");
+      uint32_t process_queue_[QUEUE_SIZE] = {0};
+      volatile uint8_t process_queue_write_ = 0; // Written by ISR, read by loop()
+      volatile uint8_t process_queue_read_ = 0;  // Written by loop(), read by ISR for overflow check
 
     protected:
       void process_frame(uint32_t);
@@ -67,16 +89,21 @@ namespace esphome
       DcBlueCover *garage_cover_sensor_{nullptr};
       cover::CoverOperation next_direction_{cover::COVER_OPERATION_OPENING};
 
-      int symbol_period_ = 900;             // us
-      unsigned long trigger_period_ = 1000; // ms
-      unsigned long clear_period_ = 1000;
+      int symbol_period_ = 900;        // us
+      uint32_t trigger_period_ = 1000; // ms
+      uint32_t clear_period_ = 1000;   // ms
 
-      int triggers_needed = 0;
+      std::atomic<int> triggers_needed{0}; // Modified by DcBlueCover, read by process_trigger()
 
-      bool pin_set = false;
-      unsigned long pin_set_time;
-      unsigned long pin_cleared_time;
-      bool pin_cleared = false;
+      // Trigger pulse state machine
+      enum class TriggerState : uint8_t
+      {
+        IDLE,
+        PIN_HIGH,
+        PIN_LOW_WAIT
+      };
+      TriggerState trigger_state_ = TriggerState::IDLE;
+      uint32_t trigger_state_time_ = 0;
     };
 
   } // namespace dc_blue

--- a/esphome/components/dc_blue/dc_blue_cover.cpp
+++ b/esphome/components/dc_blue/dc_blue_cover.cpp
@@ -29,6 +29,12 @@ namespace esphome
 
         void DcBlueCover::control(const cover::CoverCall &call)
         {
+            if (this->triggers_needed_ == nullptr)
+            {
+                ESP_LOGE(TAG, "triggers_needed not set - cover not properly initialized");
+                return;
+            }
+
             if (call.get_stop())
             {
                 ESP_LOGD(TAG, "Got stop command");

--- a/esphome/components/dc_blue/dc_blue_cover.h
+++ b/esphome/components/dc_blue/dc_blue_cover.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include "esphome/components/cover/cover.h"
 #include "esphome/components/cover/cover_traits.h"
 #include "esphome/core/gpio.h"
@@ -14,11 +15,11 @@ namespace esphome
         public:
             void setup();
             cover::CoverTraits get_traits() override;
-            void set_triggers_needed(int *triggers_needed) { this->triggers_needed_ = triggers_needed; }
+            void set_triggers_needed(std::atomic<int> *triggers_needed) { this->triggers_needed_ = triggers_needed; }
 
         protected:
             void control(const cover::CoverCall &call) override;
-            int *triggers_needed_;
+            std::atomic<int> *triggers_needed_{nullptr};
         };
 
     } // namespace dc_blue


### PR DESCRIPTION
Since ESPHome 25.10.0 Arduino is now an IDF Component as a opposed to the previously precompiled framework. This PR now allows you to use the esp-idf platform natively, which will reduce ram, binary size and compile time. Arduino platform is still supported.

https://esphome.io/changelog/2025.10.0/#arduino-as-idf-component-major-architectural-change